### PR TITLE
Make Release() public to allow for better management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ deps:
 test: deps
 	@go list ./... | grep -v /vendor/ | xargs -n1 godep go test
 
+bench: deps
+	@godep go test -run=XXX -benchtime=5s -bench=. ./...
+
 .PNONY: all deps test

--- a/image_test.go
+++ b/image_test.go
@@ -33,13 +33,15 @@ func TestDecodePNG(t *testing.T) {
 func BenchmarkDecodeJPEG(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buffer := bytes.NewBuffer(lennaJPG)
-		Decode(buffer)
+		img, _ := Decode(buffer)
+		img.Release()
 	}
 }
 
 func BenchmarkDecodePNG(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buffer := bytes.NewBuffer(lennaPNG)
-		Decode(buffer)
+		img, _ := Decode(buffer)
+		img.Release()
 	}
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -22,6 +22,14 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, 100, resized.Bounds().Dy())
 }
 
+func TestFit(t *testing.T) {
+	resized, _ := Fit(mlk, 100, 100)
+
+	assert.Equal(t, "663fc1b903e0e4090f926687cc55c6829f57fa37", fmt.Sprintf("%x", sha1.Sum(resized.Bytes())))
+	assert.Equal(t, 100, resized.Bounds().Dx())
+	assert.Equal(t, 96, resized.Bounds().Dy())
+}
+
 func TestReorient1(t *testing.T) {
 	reoriented, _ := Reorient(testImg("orientations/orientation-1.jpg"))
 
@@ -124,4 +132,60 @@ func TestFlipV(t *testing.T) {
 	assert.Equal(t, "3d756cbb38ec4327986d84e8971093cda2712e39", fmt.Sprintf("%x", sha1.Sum(flipped.Bytes())))
 	assert.Equal(t, 525, flipped.Bounds().Dx())
 	assert.Equal(t, 504, flipped.Bounds().Dy())
+}
+
+func BenchmarkResizeDown(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := Resize(mlk, 100, 100)
+		img.Release()
+	}
+}
+
+func BenchmarkResizeUp(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := Resize(mlk, 1000, 1000)
+		img.Release()
+	}
+}
+
+func BenchmarkFit(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := Fit(mlk, 100, 100)
+		img.Release()
+	}
+}
+
+func BenchmarkRotate90(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := Rotate90(mlk)
+		img.Release()
+	}
+}
+
+func BenchmarkRotate180(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := Rotate180(mlk)
+		img.Release()
+	}
+}
+
+func BenchmarkRotate270(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := Rotate270(mlk)
+		img.Release()
+	}
+}
+
+func BenchmarkFlipH(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := FlipH(mlk)
+		img.Release()
+	}
+}
+
+func BenchmarkFlipV(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img, _ := FlipH(mlk)
+		img.Release()
+	}
 }


### PR DESCRIPTION
Because Go's GC doesn't see into the C heap, it's important to manually release as soon as the memory is no longer needed. Otherwise memory can stick around for way too long.

Also added additional tests for transform.go