### PR TITLE
Move transform API to struct methods for easier memory management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ test: deps
 	@go list ./... | grep -v /vendor/ | xargs -n1 godep go test
 
 bench: deps
-	@godep go test -run=XXX -benchtime=5s -bench=. ./...
+	@go list ./... | grep -v /vendor/ | xargs -n1 godep go test -run=XXX -benchtime=1s -bench=.
 
 .PNONY: all deps test

--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ import(
 func main() {
   f, _ := os.Open("example.jpg")
 
-  var img prism.Image
-  img, _ = prism.Decode(f)
-  img, _ = prism.FlipV(img)
-  img, _ = prism.Fit(img, 500, 500)
+  img, _ := prism.Decode(f)
+  _ = img.FlipV()
+  _ = img.Fit(500, 500)
 
   w, _ := os.Create("resized.jpg")
   defer w.Close()

--- a/encode_test.go
+++ b/encode_test.go
@@ -20,15 +20,6 @@ func init() {
 	lenna = testImg("lenna.png")
 }
 
-func testImg(name string) *Image {
-	b, err := ioutil.ReadFile("./testdata/" + name)
-	img, err := Decode(bytes.NewBuffer(b))
-	if err != nil {
-		panic(err)
-	}
-	return img
-}
-
 func TestEncodeJPEG85(t *testing.T) {
 	var enc bytes.Buffer
 	EncodeJPEG(bufio.NewWriter(&enc), lenna, 85)

--- a/example/cli.go
+++ b/example/cli.go
@@ -38,12 +38,9 @@ func main() {
 		panic(err)
 	}
 
-	reoriented, err := prism.Reorient(img)
-	if err != nil {
-		reoriented = img
-	}
+	_ = img.Reorient()
 
-	resized, err := prism.Fit(reoriented, width, height)
+	err = img.Fit(width, height)
 	if err != nil {
 		panic(err)
 	}
@@ -54,9 +51,9 @@ func main() {
 
 	switch format {
 	case "png":
-		err = prism.EncodePNG(w, resized, 4)
+		err = prism.EncodePNG(w, img, 4)
 	case "jpg", "jpeg":
-		err = prism.EncodeJPEG(w, resized, 85)
+		err = prism.EncodeJPEG(w, img, 85)
 	}
 
 	if err != nil {

--- a/image.go
+++ b/image.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"io/ioutil"
 	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/rwcarlsen/goexif/exif"
@@ -24,10 +25,11 @@ import (
 type Image struct {
 	iplImage *C.IplImage
 	exif     *exif.Exif
+	m        *sync.Mutex
 }
 
 func newImage(iplImage *C.IplImage, meta *exif.Exif) *Image {
-	image := &Image{iplImage, meta}
+	image := &Image{iplImage, meta, new(sync.Mutex)}
 	runtime.SetFinalizer(image, func(img *Image) { img.Release() })
 	return image
 }
@@ -52,6 +54,10 @@ func Decode(r io.Reader) (img *Image, err error) {
 
 func (img *Image) Bytes() []byte {
 	return C.GoBytes(unsafe.Pointer(img.iplImage.imageData), img.iplImage.imageSize)
+}
+
+func (img *Image) Copy() *Image {
+	return newImage(C.cvCloneImage(img.iplImage), img.exif)
 }
 
 // image.Image interface
@@ -110,27 +116,13 @@ func (img *Image) At(x, y int) color.Color {
 }
 
 func (img *Image) Bounds() image.Rectangle {
-	size := C.cvGetSize(unsafe.Pointer(img.iplImage))
-	return image.Rect(0, 0, int(size.width), int(size.height))
+	return image.Rect(0, 0, int(img.iplImage.width), int(img.iplImage.height))
 }
 
 func (img *Image) Release() {
-	if img.iplImage != nil {
-		C.cvReleaseImage(&img.iplImage)
-		img.iplImage = nil
-	}
-}
+	img.m.Lock()
+	defer img.m.Unlock()
 
-// create target image
-
-func (img *Image) cloneTarget() *Image {
-	return img.cloneResizeTarget(img.Bounds().Size().X, img.Bounds().Size().Y)
-}
-
-// create target image with new size, but same color depth and channels
-
-func (img *Image) cloneResizeTarget(width, height int) *Image {
-	size := C.CvSize{width: C.int(width), height: C.int(height)}
-	newIpl := C.cvCreateImage(size, img.iplImage.depth, img.iplImage.nChannels)
-	return newImage(newIpl, img.exif)
+	C.cvReleaseImage(&img.iplImage)
+	img.iplImage = nil
 }

--- a/image_test.go
+++ b/image_test.go
@@ -20,6 +20,15 @@ func init() {
 	lennaPNG = png
 }
 
+func testImg(name string) *Image {
+	b, err := ioutil.ReadFile("./testdata/" + name)
+	img, err := Decode(bytes.NewBuffer(b))
+	if err != nil {
+		panic(err)
+	}
+	return img
+}
+
 func TestDecodeJPEG(t *testing.T) {
 	img, _ := Decode(bytes.NewBuffer(lennaJPG))
 	assert.Equal(t, "968a15332343a2794fe7b55f65bd02635e173aad", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))

--- a/transform_test.go
+++ b/transform_test.go
@@ -8,184 +8,225 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var mlk *Image
-
-func init() {
-	mlk = testImg("mlk.png")
-}
-
 func TestResize(t *testing.T) {
-	resized, _ := Resize(mlk, 100, 100)
+	img := testImg("mlk.png")
+	_ = img.Resize(100, 100)
 
-	assert.Equal(t, "a8e50040e1a0219b3f2dd7710917f101048e071e", fmt.Sprintf("%x", sha1.Sum(resized.Bytes())))
-	assert.Equal(t, 100, resized.Bounds().Dx())
-	assert.Equal(t, 100, resized.Bounds().Dy())
+	assert.Equal(t, "a8e50040e1a0219b3f2dd7710917f101048e071e", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 100, img.Bounds().Dx())
+	assert.Equal(t, 100, img.Bounds().Dy())
 }
 
 func TestFit(t *testing.T) {
-	resized, _ := Fit(mlk, 100, 100)
+	img := testImg("mlk.png")
+	_ = img.Fit(100, 100)
 
-	assert.Equal(t, "663fc1b903e0e4090f926687cc55c6829f57fa37", fmt.Sprintf("%x", sha1.Sum(resized.Bytes())))
-	assert.Equal(t, 100, resized.Bounds().Dx())
-	assert.Equal(t, 96, resized.Bounds().Dy())
+	assert.Equal(t, "663fc1b903e0e4090f926687cc55c6829f57fa37", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 100, img.Bounds().Dx())
+	assert.Equal(t, 96, img.Bounds().Dy())
 }
 
 func TestReorient1(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-1.jpg"))
+	img := testImg("orientations/orientation-1.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "06d6a0c8dbdc3229b8ea8d1fe257c890baa41088", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "06d6a0c8dbdc3229b8ea8d1fe257c890baa41088", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient2(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-2.jpg"))
+	img := testImg("orientations/orientation-2.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "0b12c9d9c59544298929fb229cb6cdcefd2e8432", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "0b12c9d9c59544298929fb229cb6cdcefd2e8432", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient3(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-3.jpg"))
+	img := testImg("orientations/orientation-3.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "3802560db62d5703a8d96c821efd3e839995e681", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "3802560db62d5703a8d96c821efd3e839995e681", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient4(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-4.jpg"))
+	img := testImg("orientations/orientation-4.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "58de3d130761d7837bc61fad72673d4ef328f18f", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "58de3d130761d7837bc61fad72673d4ef328f18f", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient5(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-5.jpg"))
+	img := testImg("orientations/orientation-5.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "101f3dc5b9834dbf00db0f0f77f71233bb6defc5", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "101f3dc5b9834dbf00db0f0f77f71233bb6defc5", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient6(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-6.jpg"))
+	img := testImg("orientations/orientation-6.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "0abcaf927976b94134156e6c0385ea3262a66457", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "0abcaf927976b94134156e6c0385ea3262a66457", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient7(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-7.jpg"))
+	img := testImg("orientations/orientation-7.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "bcf54553b6b7a0157caf25f56147256c75298706", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "bcf54553b6b7a0157caf25f56147256c75298706", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestReorient8(t *testing.T) {
-	reoriented, _ := Reorient(testImg("orientations/orientation-8.jpg"))
+	img := testImg("orientations/orientation-8.jpg")
+	_ = img.Reorient()
 
-	assert.Equal(t, "22e656fb927de87e9081c14d34375bb960a9444b", fmt.Sprintf("%x", sha1.Sum(reoriented.Bytes())))
-	assert.Equal(t, 480, reoriented.Bounds().Dx())
-	assert.Equal(t, 640, reoriented.Bounds().Dy())
+	assert.Equal(t, "22e656fb927de87e9081c14d34375bb960a9444b", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 480, img.Bounds().Dx())
+	assert.Equal(t, 640, img.Bounds().Dy())
 }
 
 func TestRotate90(t *testing.T) {
-	rotated, _ := Rotate90(mlk)
+	img := testImg("mlk.png")
+	_ = img.Rotate90()
 
-	assert.Equal(t, "26837accfb14ffb4c40e4ae431a832325d304791", fmt.Sprintf("%x", sha1.Sum(rotated.Bytes())))
-	assert.Equal(t, 504, rotated.Bounds().Dx())
-	assert.Equal(t, 525, rotated.Bounds().Dy())
+	assert.Equal(t, "26837accfb14ffb4c40e4ae431a832325d304791", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 504, img.Bounds().Dx())
+	assert.Equal(t, 525, img.Bounds().Dy())
 }
 
 func TestRotate180(t *testing.T) {
-	rotated, _ := Rotate180(mlk)
+	img := testImg("mlk.png")
+	_ = img.Rotate180()
 
-	assert.Equal(t, "017080651c5e51d8d07ea49de722b3f84f4b271f", fmt.Sprintf("%x", sha1.Sum(rotated.Bytes())))
-	assert.Equal(t, 525, rotated.Bounds().Dx())
-	assert.Equal(t, 504, rotated.Bounds().Dy())
+	assert.Equal(t, "017080651c5e51d8d07ea49de722b3f84f4b271f", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 525, img.Bounds().Dx())
+	assert.Equal(t, 504, img.Bounds().Dy())
 }
 
 func TestRotate270(t *testing.T) {
-	rotated, _ := Rotate270(mlk)
+	img := testImg("mlk.png")
+	_ = img.Rotate270()
 
-	assert.Equal(t, "302d7317bafe41022c7e0bf7020b417e586c527e", fmt.Sprintf("%x", sha1.Sum(rotated.Bytes())))
-	assert.Equal(t, 504, rotated.Bounds().Dx())
-	assert.Equal(t, 525, rotated.Bounds().Dy())
+	assert.Equal(t, "302d7317bafe41022c7e0bf7020b417e586c527e", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 504, img.Bounds().Dx())
+	assert.Equal(t, 525, img.Bounds().Dy())
 }
 
 func TestFlipH(t *testing.T) {
-	flipped, _ := FlipH(mlk)
+	img := testImg("mlk.png")
+	_ = img.FlipH()
 
-	assert.Equal(t, "92dc081f5d70eb0d2d103419dec3d6ffb416ac44", fmt.Sprintf("%x", sha1.Sum(flipped.Bytes())))
-	assert.Equal(t, 525, flipped.Bounds().Dx())
-	assert.Equal(t, 504, flipped.Bounds().Dy())
+	assert.Equal(t, "92dc081f5d70eb0d2d103419dec3d6ffb416ac44", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 525, img.Bounds().Dx())
+	assert.Equal(t, 504, img.Bounds().Dy())
 }
 
 func TestFlipV(t *testing.T) {
-	flipped, _ := FlipV(mlk)
+	img := testImg("mlk.png")
+	_ = img.FlipV()
 
-	assert.Equal(t, "3d756cbb38ec4327986d84e8971093cda2712e39", fmt.Sprintf("%x", sha1.Sum(flipped.Bytes())))
-	assert.Equal(t, 525, flipped.Bounds().Dx())
-	assert.Equal(t, 504, flipped.Bounds().Dy())
+	assert.Equal(t, "3d756cbb38ec4327986d84e8971093cda2712e39", fmt.Sprintf("%x", sha1.Sum(img.Bytes())))
+	assert.Equal(t, 525, img.Bounds().Dx())
+	assert.Equal(t, 504, img.Bounds().Dy())
 }
 
 func BenchmarkResizeDown(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := Resize(mlk, 100, 100)
+		img := mlk.Copy()
+		_ = img.Resize(100, 100)
 		img.Release()
 	}
 }
 
 func BenchmarkResizeUp(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := Resize(mlk, 1000, 1000)
+		img := mlk.Copy()
+		_ = img.Resize(1000, 1000)
 		img.Release()
 	}
 }
 
 func BenchmarkFit(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := Fit(mlk, 100, 100)
+		img := mlk.Copy()
+		_ = img.Fit(100, 100)
 		img.Release()
 	}
 }
 
 func BenchmarkRotate90(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := Rotate90(mlk)
+		img := mlk.Copy()
+		_ = img.Rotate90()
 		img.Release()
 	}
 }
 
 func BenchmarkRotate180(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := Rotate180(mlk)
+		img := mlk.Copy()
+		_ = img.Rotate180()
 		img.Release()
 	}
 }
 
 func BenchmarkRotate270(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := Rotate270(mlk)
+		img := mlk.Copy()
+		_ = img.Rotate270()
 		img.Release()
 	}
 }
 
 func BenchmarkFlipH(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := FlipH(mlk)
+		img := mlk.Copy()
+		_ = img.FlipH()
 		img.Release()
 	}
 }
 
 func BenchmarkFlipV(b *testing.B) {
+	mlk := testImg("mlk.png")
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
-		img, _ := FlipH(mlk)
+		img := mlk.Copy()
+		_ = img.FlipH()
 		img.Release()
 	}
 }


### PR DESCRIPTION
When combining transformations, previously it was necessary to release every intermediate state manually. This is complex and error-prone. By using struct methods, the image can release its previous memory itself.

The package-based API is still kinda nice for a number of reasons, so we may bring it back someday—but for now it's easier to maintain one.

Includes #7 as well.