### PR TITLE
Properly free allocated buffer when decode fails and allow JPEG warnings

### DIFF
--- a/prism.c
+++ b/prism.c
@@ -3,7 +3,7 @@
 int isRecoverableError(char* errorStr) {
   if (!strcmp(errorStr, "Invalid SOS parameters for sequential JPEG") ||
       !strcmp(errorStr, "Premature end of JPEG file")) {
-      return 1;
+    return 1;
   }
   return 0;
 }
@@ -40,8 +40,8 @@ IplImage* prismDecode(void* data, unsigned int dataSize) {
 
   unsigned char* buffer = cvAlloc(width * height * channels);
   err = tjDecompress2(
-    jpeg, (unsigned char*)data, dataSize, buffer, 0, 0, 0, pixelFmt, TJFLAG_FASTDCT
-  );
+          jpeg, (unsigned char*)data, dataSize, buffer, 0, 0, 0, pixelFmt, TJFLAG_FASTDCT
+        );
   tjDestroy(jpeg);
 
   if (err) {
@@ -61,18 +61,18 @@ IplImage* prismDecode(void* data, unsigned int dataSize) {
 PrismEncoded* prismEncodeJPEG(IplImage* img, int quality) {
   int pixFmt, subsamp;
 
-  switch(img->nChannels) {
-    case 1:
-      pixFmt = TJPF_GRAY;
-      subsamp = TJSAMP_GRAY;
-      break;
-    case 4:
-      pixFmt = TJPF_BGRA;
-      subsamp = TJSAMP_420;
-      break;
-    default:
-      pixFmt = TJPF_BGR;
-      subsamp = TJSAMP_420;
+  switch (img->nChannels) {
+  case 1:
+    pixFmt = TJPF_GRAY;
+    subsamp = TJSAMP_GRAY;
+    break;
+  case 4:
+    pixFmt = TJPF_BGRA;
+    subsamp = TJSAMP_420;
+    break;
+  default:
+    pixFmt = TJPF_BGR;
+    subsamp = TJSAMP_420;
   }
 
   int err;
@@ -81,9 +81,9 @@ PrismEncoded* prismEncodeJPEG(IplImage* img, int quality) {
   PrismEncoded* enc = calloc(1, sizeof(PrismEncoded));
 
   err = tjCompress2(
-    jpeg, (unsigned char*)img->imageData, size.width, img->widthStep,
-    size.height, pixFmt, &enc->buffer, &enc->size, subsamp, quality, 0
-  );
+          jpeg, (unsigned char*)img->imageData, size.width, img->widthStep,
+          size.height, pixFmt, &enc->buffer, &enc->size, subsamp, quality, 0
+        );
   tjDestroy(jpeg);
 
   if (err) {

--- a/prism.h
+++ b/prism.h
@@ -8,9 +8,9 @@
 #include <turbojpeg.h>
 
 typedef struct {
-    unsigned char* buffer;
-    unsigned long size;
-    CvMat* _mat;
+  unsigned char* buffer;
+  unsigned long size;
+  CvMat* _mat;
 } PrismEncoded;
 
 PrismEncoded* prismEncodeJPEG(IplImage* img, int quality);


### PR DESCRIPTION
Two things: there was a free bug, and we were failing on a JPEG warning.

https://github.com/libjpeg-turbo/libjpeg-turbo/issues/112
https://github.com/owncloud/core/issues/21873